### PR TITLE
Allow to override Redis defaults settings from global sails.config.redis

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,9 @@ module.exports = function(sails) {
     //reference kue based queue
     var publisher;
     /**
-     * Retrieve the default hooks configs with any other global redis config
+     * Extend the default hooks configs with any other global redis config
      */
-    function getDefaultConfig() {
-      //get extended default config
-      var config = sails.config[this.configKey] || {};
+    function extendDefaultConfig(config) {
       // extend any custom redis configs based on specific global env config
       if (sails.config.redis) { 
         config = Object.assign(config, {'redis':Object.assign(config.redis, sails.config.redis)});
@@ -74,7 +72,7 @@ module.exports = function(sails) {
             //extend defaults configuration
             //with provided configuration from sails
             //config
-            var config = getDefaultConfig.call(this);
+            var config = extendDefaultConfig(sails.config[this.configKey]);
             
             // If the hook has been deactivated, just return
             if (!config.active) {

--- a/index.js
+++ b/index.js
@@ -11,6 +11,19 @@ module.exports = function(sails) {
 
     //reference kue based queue
     var publisher;
+    /**
+     * Retrieve the default hooks configs with any other global redis config
+     */
+    function getDefaultConfig() {
+      //get extended default config
+      var config = sails.config[this.configKey] || {};
+      // extend any custom redis configs based on specific global env config
+      if (sails.config.redis) { 
+        config = Object.assign(config, {'redis':Object.assign(config.redis, sails.config.redis)});
+      }
+    
+      return config;
+    }
 
     //return hook
     return {
@@ -61,8 +74,8 @@ module.exports = function(sails) {
             //extend defaults configuration
             //with provided configuration from sails
             //config
-            var config = sails.config[this.configKey];
-
+            var config = getDefaultConfig.call(this);
+            
             // If the hook has been deactivated, just return
             if (!config.active) {
                 sails.log.info('sails-hooks-publisher deactivated.');

--- a/test/bootstrap.spec.js
+++ b/test/bootstrap.spec.js
@@ -14,6 +14,7 @@ before(function(done) {
         .lift({ // configuration for testing purposes
             port: 7070,
             environment: 'test',
+            redis:{host: '127.0.0.1'},
             log: {
                 noShip: true
             },

--- a/test/bootstrap.spec.js
+++ b/test/bootstrap.spec.js
@@ -14,7 +14,9 @@ before(function(done) {
         .lift({ // configuration for testing purposes
             port: 7070,
             environment: 'test',
-            redis:{host: '127.0.0.1'},
+            redis: {
+              host: '127.0.0.1'
+            },
             log: {
                 noShip: true
             },

--- a/test/publisher.spec.js
+++ b/test/publisher.spec.js
@@ -24,6 +24,11 @@ describe('Hook#publisher', function() {
         done();
     });
 
+    it('should be able to use redis config from global sails.config', function(done) {
+      expect(sails.config.publisher.redis.host).to.equal(sails.config.redis.host);
+      done();
+    });
+
     it('should have a queue to create job(s) and listen for queue events', function(done) {
         var publisher = sails.hooks.publisher;
 


### PR DESCRIPTION
# Problem 
Certain users may need the ability  to set different Redis connection settings on different server environments, Ex. Staging or Production.

# Proposed Solution
Allow the hook to receive and override Redis config from a global `sails.config.redis`.  This provides flexibility to specify custom configurations on different server environments. 

Any feedback is welcomed.

Thanks!